### PR TITLE
Add Core Data backed clipboard entries with iCloud sync

### DIFF
--- a/ClipVault/ClipVaultApp.swift
+++ b/ClipVault/ClipVaultApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct ClipVaultApp: App {
+    let persistenceController = PersistenceController.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(context: persistenceController.container.viewContext)
+                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+        }
+    }
+}

--- a/ClipVault/Models/CoreData/ClipboardEntry.swift
+++ b/ClipVault/Models/CoreData/ClipboardEntry.swift
@@ -1,0 +1,25 @@
+import Foundation
+import CoreData
+import AppKit
+
+@objc(ClipboardEntry)
+public class ClipboardEntry: NSManagedObject {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ClipboardEntry> {
+        NSFetchRequest<ClipboardEntry>(entityName: "ClipboardEntry")
+    }
+
+    @NSManaged public var id: UUID
+    @NSManaged public var originalName: String
+    @NSManaged public var fileExtension: String
+    @NSManaged public var type: String
+    @NSManaged public var previewData: Data?
+    @NSManaged public var contentData: Data
+    @NSManaged public var date: Date
+
+    var previewImage: NSImage? {
+        if let data = previewData {
+            return NSImage(data: data)
+        }
+        return nil
+    }
+}

--- a/ClipVault/Services/PersistenceController.swift
+++ b/ClipVault/Services/PersistenceController.swift
@@ -1,0 +1,85 @@
+import Foundation
+import CoreData
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentCloudKitContainer
+
+    init(inMemory: Bool = false) {
+        let model = Self.managedObjectModel
+        container = NSPersistentCloudKitContainer(name: "ClipVault", managedObjectModel: model)
+
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        if let description = container.persistentStoreDescriptions.first {
+            description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+            description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+            description.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(containerIdentifier: "iCloud.com.example.clipvault")
+        }
+
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+
+    static var managedObjectModel: NSManagedObjectModel = {
+        let model = NSManagedObjectModel()
+
+        let entity = NSEntityDescription()
+        entity.name = "ClipboardEntry"
+        entity.managedObjectClassName = "ClipboardEntry"
+
+        var properties: [NSAttributeDescription] = []
+
+        let idAttr = NSAttributeDescription()
+        idAttr.name = "id"
+        idAttr.attributeType = .UUIDAttributeType
+        idAttr.isOptional = false
+        properties.append(idAttr)
+
+        let nameAttr = NSAttributeDescription()
+        nameAttr.name = "originalName"
+        nameAttr.attributeType = .stringAttributeType
+        nameAttr.isOptional = false
+        properties.append(nameAttr)
+
+        let extAttr = NSAttributeDescription()
+        extAttr.name = "fileExtension"
+        extAttr.attributeType = .stringAttributeType
+        extAttr.isOptional = false
+        properties.append(extAttr)
+
+        let typeAttr = NSAttributeDescription()
+        typeAttr.name = "type"
+        typeAttr.attributeType = .stringAttributeType
+        typeAttr.isOptional = false
+        properties.append(typeAttr)
+
+        let previewAttr = NSAttributeDescription()
+        previewAttr.name = "previewData"
+        previewAttr.attributeType = .binaryDataAttributeType
+        previewAttr.isOptional = true
+        properties.append(previewAttr)
+
+        let dataAttr = NSAttributeDescription()
+        dataAttr.name = "contentData"
+        dataAttr.attributeType = .binaryDataAttributeType
+        dataAttr.isOptional = false
+        properties.append(dataAttr)
+
+        let dateAttr = NSAttributeDescription()
+        dateAttr.name = "date"
+        dateAttr.attributeType = .dateAttributeType
+        dateAttr.isOptional = false
+        properties.append(dateAttr)
+
+        entity.properties = properties
+        model.entities = [entity]
+        return model
+    }()
+}

--- a/ClipVault/ViewModels/ClipboardViewModel.swift
+++ b/ClipVault/ViewModels/ClipboardViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import AppKit
+import CoreData
+import UniformTypeIdentifiers
+
+final class ClipboardViewModel: ObservableObject {
+    private let pasteboard = NSPasteboard.general
+    private var changeCount: Int
+    private let context: NSManagedObjectContext
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+        self.changeCount = pasteboard.changeCount
+        startMonitoring()
+    }
+
+    private func startMonitoring() {
+        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.checkPasteboard()
+        }
+    }
+
+    private func checkPasteboard() {
+        guard pasteboard.changeCount != changeCount else { return }
+        changeCount = pasteboard.changeCount
+
+        guard let item = pasteboard.pasteboardItems?.first else { return }
+        guard let type = item.types.first, let data = item.data(forType: type) else { return }
+
+        let entry = ClipboardEntry(context: context)
+        entry.id = UUID()
+        entry.date = Date()
+        entry.originalName = "ClipboardItem"
+        entry.fileExtension = UTType(type.rawValue)?.preferredFilenameExtension ?? ""
+        entry.type = determineType(for: type)
+        entry.contentData = data
+
+        if type == .string {
+            entry.previewData = data
+        } else if let image = NSImage(data: data) {
+            entry.previewData = image.tiffRepresentation
+        }
+
+        try? context.save()
+    }
+
+    private func determineType(for pasteboardType: NSPasteboard.PasteboardType) -> String {
+        if pasteboardType == .string { return "text" }
+        if pasteboardType == .png || pasteboardType == .tiff { return "image" }
+        return "file"
+    }
+
+    func copyToPasteboard(_ entry: ClipboardEntry) {
+        pasteboard.clearContents()
+        if entry.type == "text" {
+            if let string = String(data: entry.contentData, encoding: .utf8) {
+                pasteboard.setString(string, forType: .string)
+            }
+        } else {
+            pasteboard.setData(entry.contentData, forType: NSPasteboard.PasteboardType(entry.fileExtension))
+        }
+    }
+}

--- a/ClipVault/Views/ContentView.swift
+++ b/ClipVault/Views/ContentView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import AppKit
+
+struct ContentView: View {
+    @Environment(\.managedObjectContext) private var context
+    @StateObject private var viewModel: ClipboardViewModel
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \ClipboardEntry.date, ascending: false)],
+        animation: .default)
+    private var entries: FetchedResults<ClipboardEntry>
+
+    init(context: NSManagedObjectContext) {
+        _viewModel = StateObject(wrappedValue: ClipboardViewModel(context: context))
+        _entries = FetchRequest(
+            sortDescriptors: [NSSortDescriptor(keyPath: \ClipboardEntry.date, ascending: false)],
+            animation: .default)
+    }
+
+    var body: some View {
+        Table(entries) {
+            TableColumn("Preview") { entry in
+                if let image = entry.previewImage {
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 40, height: 40)
+                } else if entry.type == "text",
+                          let text = String(data: entry.contentData, encoding: .utf8) {
+                    Text(text).lineLimit(1)
+                } else {
+                    Image(nsImage: NSWorkspace.shared.icon(forFileType: entry.fileExtension))
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 40, height: 40)
+                }
+            }
+            TableColumn("Name") { entry in
+                Text(entry.originalName)
+            }
+            TableColumn("Extension") { entry in
+                Text(entry.fileExtension)
+            }
+            TableColumn("Date") { entry in
+                Text(entry.date, style: .time)
+            }
+            TableColumn("Copy") { entry in
+                Button("Copy") {
+                    viewModel.copyToPasteboard(entry)
+                }
+            }
+        }
+        .frame(minWidth: 500, minHeight: 400)
+    }
+}
+
+#Preview
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView(context: PersistenceController.shared.container.viewContext)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ClipVault",
+    platforms: [
+        .macOS(.v12)
+    ],
+    products: [
+        .executable(name: "ClipVault", targets: ["ClipVault"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "ClipVault",
+            dependencies: [],
+            path: "ClipVault"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# ClipVault
+
+ClipVault is a clipboard manager for macOS built with SwiftUI. It stores everything you copy—text, images, videos and common documents—using Core Data with iCloud synchronization.
+
+## Features
+
+- Monitors the system clipboard and stores all content types in a Core Data database.
+- iCloud support via `NSPersistentCloudKitContainer` to keep your history in sync.
+- Shows previews for text and images and file icons for other formats.
+- Allows copying any item back to the system pasteboard with a single button.
+
+## Requirements
+
+- macOS 12 or later
+- Xcode 15 or later
+
+## Building
+
+Open the repository in Xcode and run the **ClipVault** scheme. The app launches and begins monitoring your clipboard automatically. Ensure your app has iCloud entitlements configured for full synchronization support.
+
+This project uses a basic MVVM architecture consisting of models, view models, and SwiftUI views. Further improvements could include persistence, advanced filtering, and better UI design.


### PR DESCRIPTION
## Summary
- introduce `PersistenceController` using `NSPersistentCloudKitContainer` for Core Data with iCloud
- add `ClipboardEntry` Core Data model
- update the view model to save clipboard data and restore items back to the pasteboard
- display clipboard history in a SwiftUI `Table` with previews/icons
- document new functionality

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686bc65309148321a70a25d4c632540c